### PR TITLE
[ADD]유저 로그인 유무에 따라 페이지 이동 제한 기능 구현

### DIFF
--- a/src/pages/login/Login.js
+++ b/src/pages/login/Login.js
@@ -31,8 +31,9 @@ function Login() {
       .then(res => {
         localStorage.setItem('access_token', res.access_token);
       })
-      .then(() => gotomain());
-
+      .then(() => {
+        gotomain();
+      });
     // } catch (err) {
     //   return err.statusCode({ message: err.message });
     // }

--- a/src/pages/main_category_report/MainCategoryReport.js
+++ b/src/pages/main_category_report/MainCategoryReport.js
@@ -25,13 +25,17 @@ function MainCategoryReport() {
     })
       .then(res => res.json())
       .then(data => {
-        if (data.message !== 'SUCCESS') {
+        if (data.message === 'LESSON ALEADY EXIST') {
+          alert('이미 요청하신 요청주제 입니다');
+          navigate('/');
+        } else if (data.message !== 'SUCCESS') {
           alert(data.message);
           navigate('/login');
         }
         setQuestion(data.questions);
       });
   }, [lecture_id]);
+
   let imgUrl = '/' + image;
   if (question === undefined) return true;
   return (

--- a/src/pages/main_category_report/MainCategoryReport.js
+++ b/src/pages/main_category_report/MainCategoryReport.js
@@ -6,24 +6,34 @@ import ReportForm from '../../components/step/ThemaCategoryForm';
 import Header from '../../components/header/Header';
 import Footer from '../../components/footer/Footer';
 import { AiFillStar } from 'react-icons/ai';
+import { useNavigate } from 'react-router-dom';
+import e from 'cors';
 
 function MainCategoryReport() {
   const location = useLocation();
   const { category, image, lecture_id } = location.state;
   const [question, setQuestion] = useState([]);
+  const navigate = useNavigate();
+
   useEffect(() => {
     //fetch('http://localhost:3000/data/hwseol/lesson_question.json', {
     fetch(`/form/questions/${lecture_id}`, {
       method: 'GET',
+      headers: {
+        token: localStorage.getItem('access_token'),
+      },
     })
       .then(res => res.json())
       .then(data => {
+        if (data.message !== 'SUCCESS') {
+          alert(data.message);
+          navigate('/login');
+        }
         setQuestion(data.questions);
       });
   }, [lecture_id]);
   let imgUrl = '/' + image;
-
-  console.log('token :', localStorage);
+  if (question === undefined) return true;
   return (
     <>
       <Header />/

--- a/src/pages/received_report/ReceivedReport.js
+++ b/src/pages/received_report/ReceivedReport.js
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import Header from '../../components/header/Header';
 import Footer from '../../components/footer/Footer';
 import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 function ReceviedBox({ _data, index }) {
   let img_datas = _data.goso_images.slice(0, 6);
@@ -49,15 +50,28 @@ function ReceviedBox({ _data, index }) {
 
 function ReceivedReport() {
   const [data, setData] = useState();
+  const navigate = useNavigate();
+
+  if (localStorage.length === 0) {
+    navigate('/login');
+  }
+
   useEffect(() => {
     //fetch('http://localhost:3000/data/hwseol/received_report.json', {
     fetch(`/receive/estimate`, {
       method: 'GET',
+      headers: {
+        token: localStorage.getItem('access_token'),
+      },
     })
       .then(res => res.json())
       .then(data => {
+        console.log(data);
+        if (data.message !== 'SUCCESS') {
+          alert(data.message);
+          navigate('/login');
+        }
         setData(data.questions);
-        //setData(data);
       });
   }, []);
 


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 아이디, 비밀번호 입력창을 사용한 로그인 기능 구현 (예시)

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 로그인 입력 데이터 유효성 검사 (예시 - 프론트)
- 입력창에 변화가 일어날 때 마다 유효성 검사 함수가 실행된다.
- 유효성 검사 함수의 반환값(boolean)에 따라 버튼의 배경색과 disabled 속성이 변화한다.
- 테스트 방법 : `/login` 페이지 이동 >>> 로그인 input 데이터 입력

2. 로그인 데이터 처리 (예시 - 백엔드)
- 조건문과 정규식을 이용한 email과 password 유효성 검사를 진행
- 유효섬 검사를 통과하지 못 할 경우 에러 메시지를 반환 예외 처리 구현

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 사용자가 발생시킬 수 있는 다양한 예외 케이스에 대해 고민하게 되었습니다. (예시)
- 문자열 데이터 입력 시 마지막에 빈 문자열이 포함되어 있는 경우 데이터 처리가 올바르게 되지 않아 유효성 검사에 빈 문자열 제거하는 로직을 추가하였습니다. (예시)

<br />

## :: 기타 질문 및 특이 사항
- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시) 
